### PR TITLE
GEN-892: fix the cat command line too long issue

### DIFF
--- a/src/cpu_stages/BamWriteStage.cpp
+++ b/src/cpu_stages/BamWriteStage.cpp
@@ -82,7 +82,7 @@ BamWriteStage::~BamWriteStage() {
        << std::setw(6) << std::setfill('0') << i
        << " ";
   }
-  ss << "> " << output_path_;
+  ss << "> " << boost::filesystem::absolute(output_path_).string();
 
   //uint64_t start_ts = getUs();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -337,8 +337,7 @@ int main(int argc, char *argv[]) {
     BamSortStage      bamsort_stage(FLAGS_t);
     BamWriteStage     bamwrite_stage(
         FLAGS_num_buckets + (!FLAGS_filter_unmap), FLAGS_temp_dir, 
-        boost::filesystem::absolute(FLAGS_output).string(), // absolute path because of "cd"
-        g_bamHeader, FLAGS_t);
+        FLAGS_output, g_bamHeader, FLAGS_t);
 
     sort_pipeline.addStage(0, &indexgen_stage);
     sort_pipeline.addStage(1, &bamread_stage);


### PR DESCRIPTION
cd to temp folder before concat
pass absolute output path to BamWriteStage

Manual tested with long temp path argument. output bam was generated as expected.
Regression tests passed.