### PR TITLE
Revert "GEN-892: fix the cat command line too long issue"

### DIFF
--- a/src/cpu_stages/BamWriteStage.cpp
+++ b/src/cpu_stages/BamWriteStage.cpp
@@ -75,14 +75,13 @@ BamWriteStage::~BamWriteStage() {
   // TODO: check if the command will be too long
   // if so, we need to cat separately to append
   std::stringstream ss;
-  ss << "cd " << bam_dir_ << " && ";
-  ss << "cat " << "./header ";
+  ss << "cat " << bam_dir_ << "/header ";
   for (int i = 0; i < num_parts_; ++i) {
-    ss << "./part-" 
+    ss << bam_dir_ << "/part-" 
        << std::setw(6) << std::setfill('0') << i
        << " ";
   }
-  ss << "> " << boost::filesystem::absolute(output_path_).string();
+  ss << "> " << output_path_;
 
   //uint64_t start_ts = getUs();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -336,8 +336,8 @@ int main(int argc, char *argv[]) {
     BamReadStage      bamread_stage(FLAGS_temp_dir, g_bamHeader, FLAGS_t);
     BamSortStage      bamsort_stage(FLAGS_t);
     BamWriteStage     bamwrite_stage(
-        FLAGS_num_buckets + (!FLAGS_filter_unmap), FLAGS_temp_dir, 
-        FLAGS_output, g_bamHeader, FLAGS_t);
+        FLAGS_num_buckets + (!FLAGS_filter_unmap),
+        FLAGS_temp_dir, FLAGS_output, g_bamHeader, FLAGS_t);
 
     sort_pipeline.addStage(0, &indexgen_stage);
     sort_pipeline.addStage(1, &bamread_stage);


### PR DESCRIPTION
Reverts falcon-computing/minimap2#7

The boost::filesystem::absolute() need to change because the xilinx library has a conflict with the boost library.