### PR TITLE
Gen-892: cat command too long

### DIFF
--- a/src/cpu_stages/BamWriteStage.cpp
+++ b/src/cpu_stages/BamWriteStage.cpp
@@ -80,9 +80,10 @@ BamWriteStage::~BamWriteStage() {
   std::string ab_output = std::string(path_buf);
 
   std::stringstream ss;
-  ss << "cat " << bam_dir_ << "/header ";
+  ss << "cd " << bam_dir_ << " && ";
+  ss << "cat " << "./header ";
   for (int i = 0; i < num_parts_; ++i) {
-    ss << bam_dir_ << "/part-" 
+    ss << "./part-" 
        << std::setw(6) << std::setfill('0') << i
        << " ";
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -336,8 +336,8 @@ int main(int argc, char *argv[]) {
     BamReadStage      bamread_stage(FLAGS_temp_dir, g_bamHeader, FLAGS_t);
     BamSortStage      bamsort_stage(FLAGS_t);
     BamWriteStage     bamwrite_stage(
-        FLAGS_num_buckets + (!FLAGS_filter_unmap),
-        FLAGS_temp_dir, FLAGS_output, g_bamHeader, FLAGS_t);
+        FLAGS_num_buckets + (!FLAGS_filter_unmap), FLAGS_temp_dir, 
+        FLAGS_output, g_bamHeader, FLAGS_t);
 
     sort_pipeline.addStage(0, &indexgen_stage);
     sort_pipeline.addStage(1, &bamread_stage);


### PR DESCRIPTION
Previous boost:: absolute function has a conflict with Xilinx library. So in this PR, a C stdlib function realpath() is used to get the absolute path.

Integration tests passed.
Tested with very long temp_dir argument, gave expected results.